### PR TITLE
fix longopt matching for non-ambiguous shared prefixes

### DIFF
--- a/getopt.go
+++ b/getopt.go
@@ -389,12 +389,19 @@ func findLongOpt(name string, overrideOpt bool, c Config) (longOpt LongOpt, foun
 	matched := []LongOpt{}
 
 	for _, lo := range c.LongOpts {
+		if lo.Name == name {
+			return lo, true
+		}
 		if strings.HasPrefix(lo.Name, name) {
 			matched = append(matched, lo)
 		}
 	}
 
 	if len(matched) == 1 {
+		return matched[0], true
+	}
+
+	if len(matched) > 0 && c.Func != FuncGetOptLongOnly {
 		return matched[0], true
 	}
 

--- a/testdata/cases.json
+++ b/testdata/cases.json
@@ -21,5 +21,8 @@
     { "label": "long_only_with_short", "args": ["prgm", "-a", "-alonga", "-ba1", "-blongb=a2", "-c", "-clongc"], "opts": "ab:c::", "lopts": "alonga,blongb:,clongc::"},
     { "label": "long_only_with_short_abbr", "args": ["prgm", "-a", "-al", "-ba1", "-bl=a2", "-c", "-cl"], "opts": "ab:c::l", "lopts": "alonga,blongb:,clongc::"},
     { "label": "permute_and_terminate", "args": ["prgm", "p1", "-a", "p2", "p3", "-ba1", "-c", "p4", "--longa", "p5", "p6", "p7", "--longb", "a2", "--", "--longc"], "opts": "ab:c::", "lopts": "longa,longb:,longc::"},
-    { "label": "kitchen_sink", "args": ["prgm", "p1", "-a", "-longa", "p2", "p3", "-ba1", "p4", "--longb=a2", "-ca3", "--longc", "--", "-a"], "opts": "ab:c::", "lopts": "longa,longb:,longc::"}
+    { "label": "kitchen_sink", "args": ["prgm", "p1", "-a", "-longa", "p2", "p3", "-ba1", "p4", "--longb=a2", "-ca3", "--longc", "--", "-a"], "opts": "ab:c::", "lopts": "longa,longb:,longc::"},
+    { "label": "ambiguous_req_arg", "args": ["prgm", "--long-a=a", "--long-ab=b", "--long=c"], "opts": "", "lopts": "long-a:,long-ab:"},
+    { "label": "ambiguous_opt_arg", "args": ["prgm", "--long-a=a", "--long-ab=b", "--long=c"], "opts": "", "lopts": "long-a::,long-ab::"},
+    { "label": "ambiguous_no_arg", "args": ["prgm", "--long-a", "--long-ab", "--long"], "opts": "", "lopts": "long-a,long-ab"}
 ]

--- a/testdata/fixtures.json
+++ b/testdata/fixtures.json
@@ -16690,5 +16690,2624 @@
             "--",
             "-a"
         ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 99,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 99,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 99,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt_long",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "c",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt_long",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "c",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt_long",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "c",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt_long_only",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt_long_only",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_req_arg",
+        "func": "getopt_long_only",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "required_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "required_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 99,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 99,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 61,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 99,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt_long",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "c",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt_long",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "c",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt_long",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "c",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt_long_only",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt_long_only",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_opt_arg",
+        "func": "getopt_long_only",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "a",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "b",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "optional_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "optional_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a=a",
+            "--long-ab=b",
+            "--long=c"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 97,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 98,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 45,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 108,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 111,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 110,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 103,
+                "name": "",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt_long",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt_long",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt_long",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt_long_only",
+        "mode": "gnu",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt_long_only",
+        "mode": "posix",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
+    },
+    {
+        "label": "ambiguous_no_arg",
+        "func": "getopt_long_only",
+        "mode": "inorder",
+        "args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ],
+        "want_results": [
+            {
+                "char": 0,
+                "name": "long-a",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long-ab",
+                "optarg": "",
+                "err": ""
+            },
+            {
+                "char": 0,
+                "name": "long",
+                "optarg": "",
+                "err": "unknown_opt"
+            },
+            {
+                "char": 0,
+                "name": "",
+                "optarg": "",
+                "err": "done"
+            }
+        ],
+        "opts": [],
+        "lopts": [
+            {
+                "name": "long-a",
+                "has_arg": "no_argument"
+            },
+            {
+                "name": "long-ab",
+                "has_arg": "no_argument"
+            }
+        ],
+        "want_optind": 4,
+        "want_args": [
+            "prgm",
+            "--long-a",
+            "--long-ab",
+            "--long"
+        ]
     }
 ]


### PR DESCRIPTION
Fixes #2.

The case where the provided name is a prefix for > 1 long option is not handled correctly. The correct behavior for long option lookup is:
1. If the name is an exact match for a long option, the lookup succeeds
2. Else, if the name is a prefix match for exactly one long option, the lookup succeeds (abbreviated long option)
3. Else:
  a. If the function being called is `getopt_long`, the lookup succeeds with the **first** matched option.
  b. If the function being called is `getopt_long_only`, the lookup is considered ambigious and fails.

The faulty implementation considered exact matches to be ambiguous in all cases.